### PR TITLE
more benchmark cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,26 +20,26 @@ benchmark-init:
 	@cargo build --release
 
 benchmark-roux: benchmark-init
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/1'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/2'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/3'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/4'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/5'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/6'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/7'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/8'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/9'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/1'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/2'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/3'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/4'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/5'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/6'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/7'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/8'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --roux < tests/random/9'
 
 benchmark-cfop: benchmark-init
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/1'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/2'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/3'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/4'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/5'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/6'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/7'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/8'
-	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/9'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/1'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/2'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/3'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/4'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/5'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/6'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/7'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/8'
+	@hyperfine -w 1 -r 8 'cargo run --release -- -q --cfop < tests/random/9'
 
 test:
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,23 @@ benchmark-roux: benchmark-init
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/1'
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/2'
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/3'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/4'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/5'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/6'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/7'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/8'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --roux < tests/random/9'
 
 benchmark-cfop: benchmark-init
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/1'
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/2'
 	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/3'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/4'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/5'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/6'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/7'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/8'
+	@hyperfine -w 1 -r 10 'cargo run --release -- -q --cfop < tests/random/9'
 
 test:
 	cargo test

--- a/tests/random/9
+++ b/tests/random/9
@@ -1,0 +1,3 @@
+Scramble {
+  F L2 F2 L2 B' D2 B U2 L2 U2 L2 U2 R D' L B2 D' F' D' B2 L
+}


### PR DESCRIPTION
以下は 52d20f6ee1ba71858f0d4ffc4f95ea00fa317333 時点のベンチマーク
NOTE:  ケースごとのバラツキは大きいので出来るだけ多くのケースで計測しましょう

## Roux

```
Benchmark 1: cargo run --release -- -q --roux < tests/random/1
  Time (mean ± σ):     151.8 ms ±  12.6 ms    [User: 142.8 ms, System: 8.9 ms]
  Range (min … max):   136.6 ms … 180.2 ms    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/2
  Time (mean ± σ):     162.0 ms ±   5.9 ms    [User: 147.1 ms, System: 14.7 ms]
  Range (min … max):   155.9 ms … 174.8 ms    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/3
  Time (mean ± σ):      1.030 s ±  0.074 s    [User: 0.867 s, System: 0.163 s]
  Range (min … max):    0.958 s …  1.181 s    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/4
  Time (mean ± σ):     108.6 ms ±  10.0 ms    [User: 96.3 ms, System: 12.3 ms]
  Range (min … max):    99.9 ms … 131.4 ms    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/5
  Time (mean ± σ):      4.676 s ±  0.203 s    [User: 3.898 s, System: 0.778 s]
  Range (min … max):    4.490 s …  4.975 s    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/6
  Time (mean ± σ):      4.797 s ±  0.178 s    [User: 4.037 s, System: 0.759 s]
  Range (min … max):    4.613 s …  5.074 s    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/7
  Time (mean ± σ):     365.7 ms ±  42.0 ms    [User: 314.0 ms, System: 51.8 ms]
  Range (min … max):   325.5 ms … 459.8 ms    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/8
  Time (mean ± σ):     983.7 ms ±  62.9 ms    [User: 857.7 ms, System: 126.0 ms]
  Range (min … max):   925.8 ms … 1102.4 ms    8 runs

Benchmark 1: cargo run --release -- -q --roux < tests/random/9
  Time (mean ± σ):      1.311 s ±  0.077 s    [User: 1.147 s, System: 0.164 s]
  Range (min … max):    1.225 s …  1.457 s    8 runs
```

## CFOP

```
Benchmark 1: cargo run --release -- -q --cfop < tests/random/1
  Time (mean ± σ):     441.2 ms ±  14.1 ms    [User: 405.0 ms, System: 36.2 ms]
  Range (min … max):   412.7 ms … 455.9 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/2
  Time (mean ± σ):     393.8 ms ±  12.9 ms    [User: 372.3 ms, System: 21.1 ms]
  Range (min … max):   375.7 ms … 412.5 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/3
  Time (mean ± σ):     190.8 ms ±  14.7 ms    [User: 176.6 ms, System: 14.2 ms]
  Range (min … max):   176.6 ms … 220.3 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/4
  Time (mean ± σ):     320.5 ms ±  12.1 ms    [User: 290.7 ms, System: 29.9 ms]
  Range (min … max):   298.8 ms … 333.1 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/5
  Time (mean ± σ):     325.0 ms ±  19.4 ms    [User: 298.4 ms, System: 26.6 ms]
  Range (min … max):   305.7 ms … 369.1 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/6
  Time (mean ± σ):     323.8 ms ±  16.0 ms    [User: 294.9 ms, System: 28.6 ms]
  Range (min … max):   302.3 ms … 357.7 ms    8 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 1: cargo run --release -- -q --cfop < tests/random/7
  Time (mean ± σ):     710.2 ms ±  11.5 ms    [User: 642.4 ms, System: 67.4 ms]
  Range (min … max):   687.4 ms … 725.5 ms    8 runs

Benchmark 1: cargo run --release -- -q --cfop < tests/random/8
  Time (mean ± σ):     985.0 ms ± 100.9 ms    [User: 917.1 ms, System: 67.9 ms]
  Range (min … max):   924.5 ms … 1229.7 ms    8 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 1: cargo run --release -- -q --cfop < tests/random/9
  Time (mean ± σ):     444.2 ms ±   8.3 ms    [User: 400.8 ms, System: 43.7 ms]
  Range (min … max):   435.4 ms … 463.1 ms    8 runs
```